### PR TITLE
Fix broken app compilation from duplicate dispatcherProvider

### DIFF
--- a/app/src/main/java/cash/p/terminal/modules/multiswap/SwapConfirmViewModel.kt
+++ b/app/src/main/java/cash/p/terminal/modules/multiswap/SwapConfirmViewModel.kt
@@ -80,7 +80,6 @@ class SwapConfirmViewModel(
     private val localStorage: ILocalStorage by inject(ILocalStorage::class.java)
     private val pendingMultiSwapStorage: PendingMultiSwapStorage by inject(PendingMultiSwapStorage::class.java)
     private val swapProviderTransactionsStorage: SwapProviderTransactionsStorage by inject(SwapProviderTransactionsStorage::class.java)
-    private val dispatcherProvider: DispatcherProvider by inject(DispatcherProvider::class.java)
 
     var sendResult by mutableStateOf<SendResult?>(null)
         private set

--- a/app/src/test/java/cash/p/terminal/modules/multiswap/SwapConfirmViewModelSaveTest.kt
+++ b/app/src/test/java/cash/p/terminal/modules/multiswap/SwapConfirmViewModelSaveTest.kt
@@ -165,7 +165,7 @@ class SwapConfirmViewModelSaveTest {
             every { sendTransactionSettingsFlow } returns MutableStateFlow(SendTransactionSettings.Common)
         }
         val adapterManager = mockk<IAdapterManager>(relaxed = true)
-        val marketKit = mockk<MarketKitWrapper>(relaxed = true)
+        val assetFiatRateService = mockk<AssetFiatRateService>(relaxed = true)
         val currencyManager = mockk<CurrencyManager> {
             every { baseCurrency } returns Currency("USD", "$", 2, 0)
         }
@@ -174,14 +174,15 @@ class SwapConfirmViewModelSaveTest {
             swapQuote = swapQuote,
             swapSettings = emptyMap(),
             currencyManager = currencyManager,
-            fiatServiceIn = FiatService(marketKit),
-            fiatServiceOut = FiatService(marketKit),
-            fiatServiceOutMin = FiatService(marketKit),
+            fiatServiceIn = FiatService(assetFiatRateService),
+            fiatServiceOut = FiatService(assetFiatRateService),
+            fiatServiceOutMin = FiatService(assetFiatRateService),
             sendTransactionService = sendTransactionService,
             timerService = TimerService(),
             priceImpactService = PriceImpactService(),
             wallet = previewWallet,
             adapterManager = adapterManager,
+            dispatcherProvider = TestDispatcherProvider(dispatcher, CoroutineScope(dispatcher)),
         )
         viewModelStore.put("test-vm", vm)
         return vm


### PR DESCRIPTION
SwapConfirmViewModel declared dispatcherProvider twice (constructor param and a `by inject` property) after two feature branches introduced the field differently and a merge kept both, which broke :app compilation. Keep the constructor parameter (the ViewModel factory injects it) and drop the redundant `by inject` property.

Update SwapConfirmViewModelSaveTest to current signatures: FiatService now takes AssetFiatRateService instead of MarketKitWrapper, and the required dispatcherProvider is now passed to the constructor.