### PR TITLE
[MOBILE-829] Handle missing transaction adapter after initialization

### DIFF
--- a/app/src/main/java/cash/p/terminal/core/managers/AdapterManager.kt
+++ b/app/src/main/java/cash/p/terminal/core/managers/AdapterManager.kt
@@ -313,8 +313,9 @@ class AdapterManager(
     override fun refreshAdapters(wallets: List<Wallet>) {
         coroutineScope.launch {
             mutex.withLock {
-                val walletsToRefresh = wallets.filter { adaptersMap.containsKey(it) }
-                val activeLitecoinMwebAccounts = walletManager.activeWallets.litecoinMwebAccountIds()
+                val activeWallets = walletManager.activeWallets
+                val walletsToRefresh = wallets.filter { it in activeWallets }
+                val activeLitecoinMwebAccounts = activeWallets.litecoinMwebAccountIds()
 
                 // remove and stop adapters
                 walletsToRefresh.forEach { wallet ->

--- a/app/src/main/java/cash/p/terminal/modules/balance/token/TokenTransactionsService.kt
+++ b/app/src/main/java/cash/p/terminal/modules/balance/token/TokenTransactionsService.kt
@@ -46,6 +46,11 @@ class TokenTransactionsService(
     private val nftMetadataService: NftMetadataService,
     private val spamManager: SpamManager,
 ) : Clearable {
+    private enum class RecordsLoadFailure {
+        AdapterUnavailable,
+        RepositoryRead,
+    }
+
     private val transactionRecordRepository: ITransactionRecordRepository by inject(
         ITransactionRecordRepository::class.java
     )
@@ -56,6 +61,8 @@ class TokenTransactionsService(
     val recordsLoadedFlow: StateFlow<Boolean> = _recordsLoadedFlow.asStateFlow()
     private val _recordsLoadFailedFlow = MutableStateFlow(false)
     val recordsLoadFailedFlow: StateFlow<Boolean> = _recordsLoadFailedFlow.asStateFlow()
+    private val recordsLoadFailureLock = Any()
+    private var recordsLoadFailure: RecordsLoadFailure? = null
     val syncingFlow: StateFlow<Boolean> = transactionSyncStateRepository.syncingFlow
     private val _searchScanStateFlow = MutableStateFlow(SearchScanState.Idle)
     val searchScanStateFlow: StateFlow<SearchScanState> = _searchScanStateFlow.asStateFlow()
@@ -116,6 +123,14 @@ class TokenTransactionsService(
             }
         }
         coroutineScope.launch {
+            // Completion is emitted only after TransactionAdapterManager has published its final
+            // adapter map. Until then a missing adapter is merely slow, not a failed history read.
+            transactionAdapterManager.initializationFlow
+                .collect { initialized ->
+                    updateAdapterUnavailableFailure(initialized)
+                }
+        }
+        coroutineScope.launch {
             // Wait for this wallet's specific adapter to be ready rather than
             // relying on initializationFlow, which may fire before all adapters
             // are in the map due to partial-batch emissions from AdapterManager.
@@ -132,6 +147,7 @@ class TokenTransactionsService(
                 .distinctUntilChanged()
                 .filterNotNull()
                 .collect {
+                    clearAdapterUnavailableFailure()
                     handleInitialization()
                 }
         }
@@ -177,12 +193,35 @@ class TokenTransactionsService(
     /** A real read is starting: the previous read's failure no longer describes the screen. */
     private fun openLoadingWindow() {
         dropToLoading()
-        _recordsLoadFailedFlow.value = false
+        setRecordsLoadFailure(null)
     }
 
     private fun markRecordsLoaded() {
         _recordsLoadedFlow.value = true
-        _recordsLoadFailedFlow.value = false
+        setRecordsLoadFailure(null)
+    }
+
+    private fun setRecordsLoadFailure(failure: RecordsLoadFailure?) =
+        synchronized(recordsLoadFailureLock) {
+            recordsLoadFailure = failure
+            _recordsLoadFailedFlow.value = failure != null
+        }
+
+    private fun updateAdapterUnavailableFailure(initialized: Boolean) =
+        synchronized(recordsLoadFailureLock) {
+            val adapterUnavailable = initialized &&
+                transactionAdapterManager.getAdapter(wallet.transactionSource) == null
+            if (recordsLoadFailure != RecordsLoadFailure.RepositoryRead) {
+                recordsLoadFailure = RecordsLoadFailure.AdapterUnavailable.takeIf { adapterUnavailable }
+                _recordsLoadFailedFlow.value = adapterUnavailable
+            }
+        }
+
+    private fun clearAdapterUnavailableFailure() = synchronized(recordsLoadFailureLock) {
+        if (recordsLoadFailure == RecordsLoadFailure.AdapterUnavailable) {
+            recordsLoadFailure = null
+            _recordsLoadFailedFlow.value = false
+        }
     }
 
     fun setTransactionType(transactionType: FilterTransactionType) {
@@ -324,7 +363,7 @@ class TokenTransactionsService(
         if (loadFailed) {
             initialClearPending = false
             emptyBatchFallbackJob?.cancel()
-            _recordsLoadFailedFlow.value = true
+            setRecordsLoadFailure(RecordsLoadFailure.RepositoryRead)
             return
         }
         // The repository emits a synthetic empty list once, when wallets are first set, to clear the

--- a/app/src/test/java/cash/p/terminal/core/managers/AdapterManagerTest.kt
+++ b/app/src/test/java/cash/p/terminal/core/managers/AdapterManagerTest.kt
@@ -63,7 +63,7 @@ class AdapterManagerTest {
         restoreModeUpdatedSubject = PublishSubject.create()
 
         walletManager = mockk(relaxed = true) {
-            every { activeWallets } returns emptyList()
+            every { activeWallets } answers { activeWalletsFlow.value }
             every { activeWalletsFlow } returns this@AdapterManagerTest.activeWalletsFlow
         }
 
@@ -472,6 +472,45 @@ class AdapterManagerTest {
             offlineModeManager.onSubscribed(walletA, newAdapter, AdapterState.Connecting)
         }
         assertSame(newAdapter, adapterManager.getAdapterForWallet<IAdapter>(walletA))
+    }
+
+    @Test
+    fun refreshAdapters_missingActiveWallet_createsAndPublishesAdapter() = testScope.runTest {
+        val walletA = wallet("account")
+        val recoveredAdapter: IAdapter = mockk(relaxed = true)
+        var creates = 0
+        coEvery { adapterFactory.getAdapterOrNull(walletA, any()) } coAnswers {
+            creates += 1
+            recoveredAdapter.takeIf { creates > 1 }
+        }
+        val observer = adapterManager.adaptersReadyObservable.test()
+
+        activeWalletsFlow.value = listOf(walletA)
+        adapterManager.startAdapterManager()
+        advanceUntilIdle()
+        assertNull(adapterManager.getAdapterForWallet<IAdapter>(walletA))
+
+        adapterManager.refreshAdapters(listOf(walletA))
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { adapterFactory.getAdapterOrNull(walletA, any()) }
+        assertSame(recoveredAdapter, adapterManager.getAdapterForWallet<IAdapter>(walletA))
+        assertTrue(observer.values().any { it[walletA] === recoveredAdapter })
+        observer.cancel()
+    }
+
+    @Test
+    fun refreshAdapters_missingInactiveWallet_doesNotCreateAdapter() = testScope.runTest {
+        val walletA = wallet("account")
+        val observer = adapterManager.adaptersReadyObservable.test()
+
+        adapterManager.refreshAdapters(listOf(walletA))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { adapterFactory.getAdapterOrNull(walletA, any()) }
+        assertNull(adapterManager.getAdapterForWallet<IAdapter>(walletA))
+        assertTrue(observer.values().none { it.containsKey(walletA) })
+        observer.cancel()
     }
 
     @Test

--- a/app/src/test/java/cash/p/terminal/modules/balance/token/TokenTransactionsServiceSearchTest.kt
+++ b/app/src/test/java/cash/p/terminal/modules/balance/token/TokenTransactionsServiceSearchTest.kt
@@ -78,8 +78,11 @@ class TokenTransactionsServiceSearchTest : KoinTest {
 
     private fun readyService(source: TransactionSource): TokenTransactionsService {
         val adapter = mockk<ITransactionsAdapter>(relaxed = true)
+        val adaptersFlow = MutableStateFlow(mapOf(source to adapter))
         every { wallet.transactionSource } returns source
-        every { adapterManager.adaptersReadyFlow } returns MutableStateFlow(mapOf(source to adapter))
+        every { adapterManager.adaptersReadyFlow } returns adaptersFlow
+        every { adapterManager.initializationFlow } returns MutableStateFlow(true)
+        every { adapterManager.getAdapter(source) } answers { adaptersFlow.value[source] }
 
         val service = TokenTransactionsService(
             wallet = wallet,

--- a/app/src/test/java/cash/p/terminal/modules/balance/token/TokenTransactionsServiceServiceVersionTest.kt
+++ b/app/src/test/java/cash/p/terminal/modules/balance/token/TokenTransactionsServiceServiceVersionTest.kt
@@ -66,6 +66,7 @@ class TokenTransactionsServiceServiceVersionTest : KoinTest {
     private val koinAdapterManager = mockk<IAdapterManager>(relaxed = true)
 
     private lateinit var repositoryItemsFlow: MutableSharedFlow<RecordsBatch>
+    private lateinit var initializationFlow: MutableStateFlow<Boolean>
 
     @get:Rule
     val koinRule = KoinTestRule.create {
@@ -80,6 +81,7 @@ class TokenTransactionsServiceServiceVersionTest : KoinTest {
     @Before
     fun setUp() {
         repositoryItemsFlow = MutableSharedFlow(replay = 0, extraBufferCapacity = 8)
+        initializationFlow = MutableStateFlow(false)
         every { repository.itemsFlow } returns repositoryItemsFlow
         every { rateRepository.dataExpiredFlow } returns MutableSharedFlow()
         every { rateRepository.historicalRateFlow } returns MutableSharedFlow()
@@ -88,6 +90,7 @@ class TokenTransactionsServiceServiceVersionTest : KoinTest {
         every { syncStateRepository.syncingFlow } returns MutableStateFlow(false)
         // emptyMap never contains wallet.transactionSource -> handleInitialization() never runs
         every { adapterManager.adaptersReadyFlow } returns MutableStateFlow(emptyMap())
+        every { adapterManager.initializationFlow } returns initializationFlow
         every { nftMetadataService.assetsBriefMetadataFlow } returns MutableStateFlow(emptyMap())
         every { spamManager.shouldHide(any()) } returns false
     }
@@ -432,36 +435,16 @@ class TokenTransactionsServiceServiceVersionTest : KoinTest {
     }
 
     @Test
-    fun start_adapterArrivesAfterLegacyTimeout_initializesWithoutFailure() = runBlocking {
-        val source = mockk<TransactionSource>(relaxed = true)
-        val adapter = mockk<ITransactionsAdapter>(relaxed = true)
-        every { wallet.transactionSource } returns source
-        every { repository.set(any(), any(), any(), any(), any(), any()) } returns true
+    fun start_adapterArrivesAfterLegacyTimeoutWhileInitializationInProgress_initializesWithoutFailure() =
+        adapterInitializationScenario().verifyLateAdapterWaitsWithoutFailure()
 
-        val adaptersFlow = MutableStateFlow<Map<TransactionSource, ITransactionsAdapter>>(emptyMap())
-        every { adapterManager.adaptersReadyFlow } returns adaptersFlow
+    @Test
+    fun start_initializationCompletesWithoutWalletAdapter_marksLoadFailedAndRetryRefreshesAdapter() =
+        adapterInitializationScenario().verifyMissingFinalAdapterFailsAndRetries()
 
-        val initializations = AtomicInteger(0)
-        every { syncStateRepository.setTransactionWallets(any()) } answers {
-            initializations.incrementAndGet()
-            Unit
-        }
-
-        val service = createService()
-        service.start()
-
-        waitUntil { adaptersFlow.subscriptionCount.value >= 1 }
-        Thread.sleep(LEGACY_ADAPTER_READY_TIMEOUT_WINDOW_MS)
-        assertFalse(service.recordsLoadFailedFlow.value)
-        assertEquals(0, initializations.get())
-
-        adaptersFlow.value = mapOf(source to adapter)
-
-        waitUntil { initializations.get() == 1 && !service.recordsLoadFailedFlow.value }
-        assertEquals(1, initializations.get())
-
-        service.clear()
-    }
+    @Test
+    fun start_adapterAppearsAfterInitializationFailure_clearsFailureAndLoadsHistory() =
+        adapterInitializationScenario().verifyLateAdapterRecoversHistory()
 
     @Test
     fun start_adapterRemoved_doesNotInitializeWithoutAdapter() = runBlocking {
@@ -832,6 +815,17 @@ class TokenTransactionsServiceServiceVersionTest : KoinTest {
         spamManager = spamManager,
     )
 
+    private fun adapterInitializationScenario() = AdapterInitializationScenario(
+        repository = repository,
+        syncStateRepository = syncStateRepository,
+        adapterManager = adapterManager,
+        wallet = wallet,
+        koinAdapterManager = koinAdapterManager,
+        initializationFlow = initializationFlow,
+        repositoryItemsFlow = repositoryItemsFlow,
+        createService = ::createService,
+    )
+
     private fun startAndAwaitSubscription(): TokenTransactionsService {
         val service = createService()
         service.start()
@@ -845,23 +839,124 @@ class TokenTransactionsServiceServiceVersionTest : KoinTest {
         every { adapterManager.adaptersReadyFlow } returns adaptersFlow
         val service = createService()
         service.start()
-        waitUntil { adaptersFlow.subscriptionCount.value >= 1 }
+        waitUntil {
+            adaptersFlow.subscriptionCount.value >= 1 && initializationFlow.subscriptionCount.value >= 1
+        }
         return service
     }
 
-    private companion object {
-        /** Wait budget for asynchronous service operations. */
-        const val ADAPTER_WAIT_MS = 10_000L
+}
 
-        /** Long enough to cross the removed wall-clock failure boundary. */
-        const val LEGACY_ADAPTER_READY_TIMEOUT_WINDOW_MS = 3_200L
+/** Wait budget for asynchronous service operations. */
+private const val ADAPTER_WAIT_MS = 10_000L
 
-        /** Outlives the service's empty-batch fallback delay. */
-        const val FALLBACK_WINDOW_MS = 1_000L
+/** Long enough to cross the removed wall-clock failure boundary. */
+private const val LEGACY_ADAPTER_READY_TIMEOUT_WINDOW_MS = 3_200L
 
-        /** Long enough for the IO collector to observe an emission that has no side effect. */
-        const val SETTLE_MS = 200L
+/** Outlives the service's empty-batch fallback delay. */
+private const val FALLBACK_WINDOW_MS = 1_000L
+
+/** Long enough for the IO collector to observe an emission that has no side effect. */
+private const val SETTLE_MS = 200L
+
+private class AdapterInitializationScenario(
+    val repository: ITransactionRecordRepository,
+    val syncStateRepository: TransactionSyncStateRepository,
+    val adapterManager: TransactionAdapterManager,
+    val wallet: Wallet,
+    val koinAdapterManager: IAdapterManager,
+    val initializationFlow: MutableStateFlow<Boolean>,
+    val repositoryItemsFlow: MutableSharedFlow<RecordsBatch>,
+    val createService: () -> TokenTransactionsService,
+)
+
+private fun AdapterInitializationScenario.verifyLateAdapterWaitsWithoutFailure() = runBlocking {
+    val source = mockk<TransactionSource>(relaxed = true)
+    val adapter = mockk<ITransactionsAdapter>(relaxed = true)
+    every { wallet.transactionSource } returns source
+    every { repository.set(any(), any(), any(), any(), any(), any()) } returns true
+    val adaptersFlow = MutableStateFlow<Map<TransactionSource, ITransactionsAdapter>>(emptyMap())
+    every { adapterManager.adaptersReadyFlow } returns adaptersFlow
+    every { adapterManager.getAdapter(source) } answers { adaptersFlow.value[source] }
+    val initializations = AtomicInteger(0)
+    every { syncStateRepository.setTransactionWallets(any()) } answers {
+        initializations.incrementAndGet()
+        Unit
     }
+
+    val service = createService()
+    service.start()
+    waitUntil {
+        adaptersFlow.subscriptionCount.value >= 1 && initializationFlow.subscriptionCount.value >= 1
+    }
+    Thread.sleep(LEGACY_ADAPTER_READY_TIMEOUT_WINDOW_MS)
+    assertFalse(service.recordsLoadFailedFlow.value)
+    assertEquals(0, initializations.get())
+
+    adaptersFlow.value = mapOf(source to adapter)
+
+    waitUntil { initializations.get() == 1 && !service.recordsLoadFailedFlow.value }
+    assertEquals(1, initializations.get())
+    verify(timeout = ADAPTER_WAIT_MS, exactly = 1) { repository.reloadItems() }
+    service.clear()
+}
+
+private fun AdapterInitializationScenario.verifyMissingFinalAdapterFailsAndRetries() = runBlocking {
+    val source = mockk<TransactionSource>(relaxed = true)
+    every { wallet.transactionSource } returns source
+    val adaptersFlow = MutableStateFlow<Map<TransactionSource, ITransactionsAdapter>>(emptyMap())
+    every { adapterManager.adaptersReadyFlow } returns adaptersFlow
+    every { adapterManager.getAdapter(source) } answers { adaptersFlow.value[source] }
+
+    val service = createService()
+    service.start()
+    waitUntil {
+        adaptersFlow.subscriptionCount.value >= 1 && initializationFlow.subscriptionCount.value >= 1
+    }
+    initializationFlow.value = true
+    waitUntil { service.recordsLoadFailedFlow.value }
+    assertFalse(service.recordsLoadedFlow.value)
+    verify(exactly = 0) { syncStateRepository.setTransactionWallets(any()) }
+    verify(exactly = 0) { repository.reloadItems() }
+
+    service.reload()
+
+    verify(exactly = 1) { koinAdapterManager.refreshAdapters(listOf(wallet)) }
+    verify(exactly = 0) { repository.reload() }
+    initializationFlow.value = false
+    waitUntil { !service.recordsLoadFailedFlow.value }
+    service.clear()
+}
+
+private fun AdapterInitializationScenario.verifyLateAdapterRecoversHistory() = runBlocking {
+    val source = mockk<TransactionSource>(relaxed = true)
+    val adapter = mockk<ITransactionsAdapter>(relaxed = true)
+    val record = mockRecord("r1", source)
+    every { wallet.transactionSource } returns source
+    every { repository.set(any(), any(), any(), any(), any(), any()) } returns true
+    val adaptersFlow = MutableStateFlow<Map<TransactionSource, ITransactionsAdapter>>(emptyMap())
+    every { adapterManager.adaptersReadyFlow } returns adaptersFlow
+    every { adapterManager.getAdapter(source) } answers { adaptersFlow.value[source] }
+
+    val service = createService()
+    service.start()
+    waitUntil {
+        repositoryItemsFlow.subscriptionCount.value >= 1 &&
+            adaptersFlow.subscriptionCount.value >= 1 &&
+            initializationFlow.subscriptionCount.value >= 1
+    }
+    initializationFlow.value = true
+    waitUntil { service.recordsLoadFailedFlow.value }
+    adaptersFlow.value = mapOf(source to adapter)
+
+    verify(timeout = ADAPTER_WAIT_MS, exactly = 1) { repository.reloadItems() }
+    waitUntil { !service.recordsLoadFailedFlow.value }
+    repositoryItemsFlow.emit(RecordsBatch(listOf(record)))
+    waitUntil {
+        service.recordsLoadedFlow.value && service.transactionItemsFlow.value.any { it.record.uid == "r1" }
+    }
+    assertFalse(service.recordsLoadFailedFlow.value)
+    service.clear()
 }
 
 /** Reports every collect, so a subscription that is released and retaken becomes observable. */


### PR DESCRIPTION
## Summary

- wait without failure while transaction adapter initialization is still in progress
- show failure and Retry only when initialization completes without the wallet source adapter
- clear adapter-specific failure and load history when the adapter later appears
- preserve the direct adapter flow collector and avoid a fixed timeout

## Verification

- TokenTransactionsServiceServiceVersionTest: 24 tests passed on Java 21
- CMF 1: no error after the legacy 3-second window; ETH history recovered automatically without Retry or restart
- CMF 1 cold start: existing ETH history visible after 4 seconds
- Detekt: unchanged 26 pre-existing findings; none in touched files